### PR TITLE
Trebuchet : Activate the default homepage selection button on first run

### DIFF
--- a/src/com/android/launcher3/Workspace.java
+++ b/src/com/android/launcher3/Workspace.java
@@ -367,7 +367,7 @@ public class Workspace extends SmoothPagedView
         mCameraDistance = res.getInteger(R.integer.config_cameraDistance);
         mOriginalDefaultPage = mDefaultPage = a.getInt(R.styleable.Workspace_defaultScreen, 1);
         mDefaultScreenId = SettingsProvider.getLongCustomDefault(context,
-            SettingsProvider.SETTINGS_UI_HOMESCREEN_DEFAULT_SCREEN_ID, -1);
+            SettingsProvider.SETTINGS_UI_HOMESCREEN_DEFAULT_SCREEN_ID, 1);
         a.recycle();
 
         setOnHierarchyChangeListener(this);


### PR DESCRIPTION
As of now, when the Trebuchet is started for the first time, the set default 
homepage button is not activated on any of the screens.
Activating it for the first time on default home screen makes more sense.

Change-Id: Ia1b7272e177707616902d20ce90ff6ba293576b4
Signed-off-by: Umair Khan omerjerk@gmail.com
