### PR TITLE
Trebuchet: send metrics values as strings

### DIFF
--- a/src/com/android/launcher3/stats/external/StatsUtil.java
+++ b/src/com/android/launcher3/stats/external/StatsUtil.java
@@ -97,7 +97,7 @@ public class StatsUtil {
         }
         Logger.logd(TAG, "Stats collection: ENABLED!");
 
-        Intent newIntent = new Intent("com.cyngn.stats.action.SEND_ANALYTIC_EVENT");
+        Intent newIntent = new Intent(ANALYTIC_INTENT);
 
         if (!trackingBundle.containsKey(KEY_TRACKING_ID)) {
             Logger.logd(TAG, "No tracking id in bundle");

--- a/src/com/android/launcher3/stats/internal/service/AggregationIntentService.java
+++ b/src/com/android/launcher3/stats/internal/service/AggregationIntentService.java
@@ -153,7 +153,7 @@ public class AggregationIntentService extends IntentService {
         Bundle bundle = TrackingBundle
                 .createTrackingBundle(TRACKING_ID, TrackingEvent.Category.HOMESCREEN_PAGE.name(),
                         "count");
-        bundle.putInt(TrackingEvent.KEY_VALUE, pageCount);
+        bundle.putString(TrackingEvent.KEY_VALUE, String.valueOf(pageCount));
         StatsUtil.sendEvent(this, bundle);
     }
 
@@ -164,7 +164,7 @@ public class AggregationIntentService extends IntentService {
         }
         Bundle bundle = TrackingBundle
                 .createTrackingBundle(TRACKING_ID, TrackingEvent.Category.WIDGET.name(), "count");
-        bundle.putInt(TrackingEvent.KEY_VALUE, widgetCount);
+        bundle.putString(TrackingEvent.KEY_VALUE, String.valueOf(widgetCount));
         StatsUtil.sendEvent(this, bundle);
     }
 


### PR DESCRIPTION
- Also refer to the declared intent

Change-Id: I3c99cc071aa2f4241ea8d3e6d2e8683f1f748e7d
Signed-off-by: Roman Birg roman@cyngn.com
