### PR TITLE
Hide workspace shortcuts during binding when AllApps is shown.

### DIFF
--- a/src/com/android/launcher3/Launcher.java
+++ b/src/com/android/launcher3/Launcher.java
@@ -4957,9 +4957,13 @@ public class Launcher extends Activity
                         }
                     }
 
+                    // If AllApps is visible, all icons should have alpha of 0f to remain hidden.
+                    if (mWorkspace.isHidden()) {
+                        shortcut.setAlpha(0f);
+                    }
                     workspace.addInScreenFromBind(shortcut, item.container, item.screenId, item.cellX,
                             item.cellY, 1, 1);
-                    if (animateIcons) {
+                    if (animateIcons && !mWorkspace.isHidden()) {
                         // Animate all the applications up now
                         shortcut.setAlpha(0f);
                         shortcut.setScaleX(0f);
@@ -4981,7 +4985,15 @@ public class Launcher extends Activity
             }
         }
 
-        if (animateIcons) {
+        // Hide all cell layouts if AllApps is currently visible.
+        if (mWorkspace.isHidden()) {
+            for (Long screenId : mWorkspace.getScreenOrder()) {
+                CellLayout cl = mWorkspace.getScreenWithId(screenId);
+                cl.setShortcutAndWidgetAlpha(0f);
+            }
+        }
+
+        if (animateIcons && !mWorkspace.isHidden()) {
             // Animate to the correct page
             if (newShortcutsScreenId > -1) {
                 long currentScreenId = mWorkspace.getScreenIdForPageIndex(mWorkspace.getNextPage());

--- a/src/com/android/launcher3/Workspace.java
+++ b/src/com/android/launcher3/Workspace.java
@@ -1111,6 +1111,10 @@ public class Workspace extends SmoothPagedView
         return mIsSwitchingState;
     }
 
+    public boolean isHidden() {
+        return mState == State.NORMAL_HIDDEN;
+    }
+
     /** This differs from isSwitchingState in that we take into account how far the transition
      *  has completed. */
     public boolean isFinishedSwitchingState() {


### PR DESCRIPTION
Previously, if All Apps was opened before the workspace items were
bound, the shortcuts would be come visible behind the app drawer when
the loading finished.

Set the alpha of the shortcuts to 0f to hide them if isAllAppsVisible()
returns true.

Change-Id: I399bf27435dfe179f64646456496b31eade864a3
